### PR TITLE
Tested and working fix for the crontab

### DIFF
--- a/install_grafana.sh
+++ b/install_grafana.sh
@@ -108,8 +108,15 @@ sudo systemctl restart grafana-server
 
 # set crontab 
 echo "* adding crontab job to start polling..."
-(crontab -u wlanpi -l 2>/dev/null; echo "*/1 * * * * /home/wlanpi/wlanpi_monitor/get_stats.sh") | crontab -u wlanpi -
-
+if crontab -u wlanpi -l &>/dev/null; then
+  # Keep existing cron jobs and add ours
+  { crontab -u wlanpi -l 2>/dev/null; echo "*/1 * * * * /home/wlanpi/wlanpi_monitor/get_stats.sh"; } | crontab -u wlanpi -
+else 
+  # There are no existing cron jobs, let's add our job as the very first one
+  echo "*/1 * * * * /home/wlanpi/wlanpi_monitor/get_stats.sh" | crontab -u wlanpi -
+fi
+echo "All cron jobs of user \"wlanpi\" after we've finished:"
+crontab -u wlanpi -l
 echo "* Done."
 
 echo ""


### PR DESCRIPTION
It failed when there were no existing cron jobs. Now the script keeps all existing jobs and either add ours, or if there are no existing jobs, it add ours as the very first job.